### PR TITLE
trailing commas are your friends, e-i-e-i-o

### DIFF
--- a/src/fooda_bot.py
+++ b/src/fooda_bot.py
@@ -100,11 +100,11 @@ def gather_fooda_context():
 def gather_food_trucks():
     """These are sorta hard-coded since there's no online source"""
     context = [
-        ("Zaaki"),
-        ("The Bacon Truck"),
-        ("Chicken on the Road", "SA PA"),
-        ("North East of the Border", "Moyzilla"),
-        ("Compliments"),
+        ("Zaaki",),
+        ("The Bacon Truck",),
+        ("Chicken on the Road", "SA PA",),
+        ("North East of the Border", "Moyzilla",),
+        ("Compliments",),
     ]
     weekday_number = datetime.datetime.today().weekday()
     try:


### PR DESCRIPTION
Fix for the 1-tuple situation. Just always trail.